### PR TITLE
feat(SearchScreen): add empty search placeholder text

### DIFF
--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/screens/SearchScreen.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/screens/SearchScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
@@ -44,6 +45,7 @@ import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.prajwalch.torrentsearch.R
 import com.prajwalch.torrentsearch.models.Category
@@ -221,6 +223,8 @@ private fun SearchScreenContent(
         if (results.isNotEmpty()) {
             TorrentList(torrents = results, onTorrentSelect = onTorrentSelect)
         }
+
+        EmptySearchPlaceholder()
     }
 }
 
@@ -264,6 +268,34 @@ private fun ResultsNotFoundMessage(modifier: Modifier = Modifier) {
             text = stringResource(R.string.msg_no_results_found),
             fontWeight = FontWeight.Bold,
         )
+    }
+}
+
+@Composable
+private fun EmptySearchPlaceholder() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            modifier = Modifier
+                .padding(horizontal = 32.dp)
+        ) {
+            Text(
+                text = stringResource(R.string.msg_page_empty),
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text = stringResource(R.string.msg_start_searching),
+                fontWeight = FontWeight.Normal,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -41,7 +41,8 @@
     <string name="hint_magnet_link_copied">Magnet link copied to clipboard!</string>
     <string name="hint_description_page_url_copied">Url copied to clipboard!</string>
     <!-- Search Screen -->
-
+    <string name="msg_page_empty">Nothing here yet</string>
+    <string name="msg_start_searching">Start searching to see results</string>
     <!-- Settings Screen -->
     <!-- Top app bar -->
     <string name="settings_screen_title">Settings</string>


### PR DESCRIPTION
* UI addition to show text initially 
<img width="216" height="480" alt="Screenshot_20250711-190829" src="https://github.com/user-attachments/assets/dcd746b0-57c4-478e-b012-fb35ce502676" />
