### PR TITLE
Introduce `Category.Mobile` for better classification

### DIFF
--- a/app/src/androidTest/kotlin/com/prajwalch/torrentsearch/ProviderTest.kt
+++ b/app/src/androidTest/kotlin/com/prajwalch/torrentsearch/ProviderTest.kt
@@ -27,10 +27,10 @@ class ProviderTest {
      */
     @Test
     fun searchReturnsRealTorrentsFromProvider() = runBlocking {
-        val searchQuery = "One Piece"
+        val searchQuery = "mod"
 
         val context = SearchContext(
-            category = Category.Books,
+            category = Category.Mobile,
             httpClient = HttpClient
         )
 

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/models/Torrent.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/models/Torrent.kt
@@ -52,6 +52,7 @@ enum class Category(val isNSFW: Boolean = false) {
     Apps,
     Books,
     Games,
+    Mobile,
     Movies,
     Music,
     Porn(isNSFW = true),

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Knaben.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Knaben.kt
@@ -120,6 +120,7 @@ class Knaben(override val id: SearchProviderId) : SearchProvider {
         Category.Porn -> listOf(5000000)
         Category.Anime -> listOf(6000000)
         Category.Games -> listOf(7000000)
+        Category.Mobile -> listOf(8000000)
         Category.Books -> listOf(9000000)
         Category.Other -> listOf(10000000)
     }
@@ -148,6 +149,7 @@ class Knaben(override val id: SearchProviderId) : SearchProvider {
      * - Porn        → 5000000
      * - Anime       → 6000000
      * - Games       → 7000000
+     * - Mobile       → 8000000
      * - Books       → 9000000
      * - Other       → 10000000
      *
@@ -176,6 +178,7 @@ class Knaben(override val id: SearchProviderId) : SearchProvider {
             in 5000000L..5999999L -> Category.Porn
             in 6000000L..6999999L -> Category.Anime
             in 7000000L..7999999L -> Category.Games
+            in 8000000L..8999999L -> Category.Mobile
             in 9000000L..9999999L -> Category.Books
             in 10000000L..10999999L -> Category.Other
             else -> Category.All

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/LimeTorrents.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/LimeTorrents.kt
@@ -35,7 +35,7 @@ class LimeTorrents(override val id: SearchProviderId) : SearchProvider {
 
     /** Returns the category string used by it. */
     private fun getCategoryString(category: Category): String = when (category) {
-        Category.All, Category.Books, Category.Porn -> "all"
+        Category.All, Category.Books, Category.Porn, Category.Mobile -> "all"
         Category.Anime -> "anime"
         Category.Apps -> "applications"
         Category.Games -> "games"

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/ThePirateBay.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/ThePirateBay.kt
@@ -46,6 +46,7 @@ class ThePirateBay(override val id: String) : SearchProvider {
         Category.Apps -> 300u
         Category.Books -> 601u
         Category.Games -> 400u
+        Category.Mobile -> 306u
         Category.Movies, Category.Series -> 200u
         Category.Music -> 101u
         Category.Porn -> 500u

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TheRarBg.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TheRarBg.kt
@@ -65,7 +65,7 @@ class TheRarBg(override val id: SearchProviderId) : SearchProvider {
 
     /** Returns the compatible category string. */
     private fun getCategoryString(category: Category): String = when (category) {
-        Category.All -> ""
+        Category.All, Category.Mobile -> ""
         Category.Anime -> "Anime"
         Category.Apps -> "Apps"
         Category.Books -> "Books"
@@ -187,6 +187,7 @@ class TheRarBg(override val id: SearchProviderId) : SearchProvider {
         "Apps" -> Category.Apps
         "Books" -> Category.Books
         "Games" -> Category.Games
+        "Android" -> Category.Mobile
         "Movies" -> Category.Movies
         "Music" -> Category.Music
         "XXX" -> Category.Porn


### PR DESCRIPTION
Although `Category.Apps` includes mobile apps, it also contains applications from other OS (Windows, MacOS, Linux..etc).

This change currently applies only to the `Knaben` and `ThePirateBay`.