### PR TITLE
implemented hiding viewed torrent filter option

### DIFF
--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/SearchScreen.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/SearchScreen.kt
@@ -252,6 +252,7 @@ fun SearchScreen(
                     SearchResultsFilter(
                         filterOptions = uiState.filterOptions,
                         onToggleDeadTorrents = viewModel::toggleDeadTorrents,
+                        onToggleHideViewed = viewModel::toggleHideViewedTorrents,
                         onToggleSearchProvider = viewModel::toggleSearchProviderResults,
                         onSelectAllSearchProviders = viewModel::selectAllSearchProviders,
                         onDeselectAllSearchProviders = viewModel::deselectAllSearchProviders,

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/SearchViewModel.kt
@@ -70,6 +70,7 @@ data class FilterOptions(
     val searchProviders: ImmutableList<SearchProviderFilterOption> = persistentListOf(),
     val deadTorrents: Boolean = true,
     val category: Category = Category.All,
+    val hideViewed: Boolean = false,
 )
 
 data class SearchProviderFilterOption(
@@ -113,12 +114,24 @@ class SearchViewModel @Inject constructor(
     )
 
     /**
+     * Set of viewed torrent IDs for efficient lookup.
+     */
+    val viewedIds: StateFlow<Set<String>> = viewedTorrentsRepository
+        .getAllViewedIds()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5.seconds),
+            initialValue = emptySet()
+        )
+
+    /**
      * The search results processor responsible for filtering, sorting, and
      * managing the related state.
      */
     private val resultsProcessor = SearchResultsProcessor(
         searchResults = searchOrchestrator.searchResults,
         settingsRepository = settingsRepository,
+        viewedIds = viewedIds,
         initialSelectedCategory = searchCategory,
     )
 
@@ -133,17 +146,6 @@ class SearchViewModel @Inject constructor(
      */
     val torrentFileDownloadEvents: Flow<TorrentFileDownloadEvent> =
         torrentFileDownloader.events
-
-    /**
-     * Set of viewed torrent IDs for efficient lookup.
-     */
-    val viewedIds: StateFlow<Set<String>> = viewedTorrentsRepository
-        .getAllViewedIds()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(5.seconds),
-            initialValue = emptySet()
-        )
 
     /**
      * The primary, read-only UI state.
@@ -216,6 +218,7 @@ class SearchViewModel @Inject constructor(
             searchProviders = searchProvidersFilterOption.toImmutableList(),
             deadTorrents = filters.deadTorrents,
             category = filters.category,
+            hideViewed = filters.hideViewed,
         )
     }
 
@@ -280,6 +283,12 @@ class SearchViewModel @Inject constructor(
 
     fun updateCategoryFilter(category: Category) {
         resultsProcessor.updateCategory(category)
+    }
+
+    fun toggleHideViewedTorrents() {
+        viewModelScope.launch {
+            resultsProcessor.toggleHideViewed()
+        }
     }
 
     fun bookmarkTorrent(torrent: Torrent) {
@@ -466,6 +475,10 @@ private class SearchResultsProcessor(
      */
     settingsRepository: SettingsRepository,
     /**
+     * Flow of viewed torrent IDs for filtering.
+     */
+    viewedIds: Flow<Set<String>>,
+    /**
      * The [Category] to use as an initial value for [Filters.category].
      */
     initialSelectedCategory: Category = Category.All,
@@ -486,6 +499,7 @@ private class SearchResultsProcessor(
         val excludedProviders: Set<String> = emptySet(),
         val deadTorrents: Boolean = true,
         val category: Category = Category.All,
+        val hideViewed: Boolean = false,
     )
 
     /**
@@ -499,9 +513,21 @@ private class SearchResultsProcessor(
     private val sortOptions = MutableStateFlow(SortOptions())
 
     /**
+     * Reference to viewed IDs flow for capturing when filter is toggled.
+     */
+    private val viewedIdsFlow = viewedIds
+
+    /**
      * The publicly observable state of the processor.
      */
     val processorState: Flow<ProcessorState> = combine(filters, sortOptions, ::ProcessorState)
+
+    /**
+     * Tracks viewed torrent IDs that should be hidden when filter is active.
+     * This is captured when hideViewed filter is enabled to avoid instant hiding
+     * of newly viewed torrents (better UX).
+     */
+    private val hiddenViewedIds = MutableStateFlow<Set<String>>(emptySet())
 
     /**
      * The asynchronous output stream of processed search results.
@@ -512,6 +538,7 @@ private class SearchResultsProcessor(
             filters,
             sortOptions,
             settingsRepository.enableNSFWMode,
+            hiddenViewedIds,
             ::processSearchResults
         ).flowOn(Dispatchers.Default)
 
@@ -530,6 +557,7 @@ private class SearchResultsProcessor(
         filters: Filters,
         sortOptions: SortOptions,
         nsfwModeEnabled: Boolean,
+        hiddenViewedIds: Set<String>,
     ): SearchResults {
         val sortComparator = createSortComparator(
             criteria = sortOptions.criteria,
@@ -541,6 +569,7 @@ private class SearchResultsProcessor(
             .filterNot { it.providerName in filters.excludedProviders }
             .filter { nsfwModeEnabled || !it.isNSFW() }
             .filter { filters.deadTorrents || !it.isDead() }
+            .filter { !filters.hideViewed || runCatching { it.id }.getOrNull() !in hiddenViewedIds }
             .filter { filters.query.isBlank() || it.name.contains(filters.query, true) }
             .filter { filters.category == Category.All || filters.category == it.category }
             .sortedWith(comparator = sortComparator)
@@ -608,5 +637,22 @@ private class SearchResultsProcessor(
      */
     fun updateSortOrder(order: SortOrder) {
         sortOptions.update { it.copy(order = order) }
+    }
+
+    /**
+     * Toggles the hide viewed filter.
+     * When enabling, captures current viewed IDs so newly viewed torrents
+     * won't instantly disappear (better UX per discussion).
+     */
+    suspend fun toggleHideViewed() {
+        val newHideViewed = !filters.value.hideViewed
+        if (newHideViewed) {
+            // Capture current viewed IDs when enabling the filter
+            hiddenViewedIds.value = viewedIdsFlow.first()
+        } else {
+            // Clear when disabling
+            hiddenViewedIds.value = emptySet()
+        }
+        filters.update { it.copy(hideViewed = newHideViewed) }
     }
 }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/component/SearchResults.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/component/SearchResults.kt
@@ -53,7 +53,11 @@ fun SearchResults(
                 )
             }
 
-            items(items = searchResults, contentType = { it.category }) {
+            items(
+                items = searchResults,
+                key = { "${it.name}_${it.providerName}" },
+                contentType = { it.category },
+            ) {
                 TorrentListItem(
                     modifier = Modifier
                         .animateItem()
@@ -66,7 +70,7 @@ fun SearchResults(
                     category = it.category,
                     providerName = it.providerName,
                     isNSFW = it.isNSFW(),
-                    isViewed = it.id in viewedIds,
+                    isViewed = runCatching { it.id in viewedIds }.getOrDefault(false),
                 )
                 HorizontalDivider()
             }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/component/SearchResultsFilter.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/ui/search/component/SearchResultsFilter.kt
@@ -32,6 +32,7 @@ import com.prajwalch.torrentsearch.ui.theme.spaces
 fun SearchResultsFilter(
     filterOptions: FilterOptions,
     onToggleDeadTorrents: () -> Unit,
+    onToggleHideViewed: () -> Unit,
     onToggleSearchProvider: (providerName: String) -> Unit,
     onSelectAllSearchProviders: () -> Unit,
     onDeselectAllSearchProviders: () -> Unit,
@@ -81,6 +82,14 @@ fun SearchResultsFilter(
                 onClick = onToggleDeadTorrents,
                 label = { Text(text = stringResource(R.string.search_filter_chip_dead_torrents)) },
                 enabled = enableDeadTorrentsFilter,
+            )
+        }
+
+        item(key = "hide_viewed") {
+            FilterChip(
+                selected = filterOptions.hideViewed,
+                onClick = onToggleHideViewed,
+                label = { Text(text = stringResource(R.string.search_filter_chip_hide_viewed)) },
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,7 @@
     <string name="search_action_view_errors">View errors</string>
     <string name="search_action_settings">Settings</string>
     <string name="search_filter_chip_dead_torrents">Dead torrents</string>
+    <string name="search_filter_chip_hide_viewed">Hide viewed</string>
     <string name="search_filter_chip_search_providers">Search providers</string>
     <string name="search_filter_providers_title">Filter by search provider</string>
     <string name="search_filter_providers_action_select_all">Select all</string>


### PR DESCRIPTION
As discribed in issue #91, maintainer said to use the `doHide` internal state but in my current implementation i have captured the currentViewed id's to `hiddenViewedIds`  state and update it with new ids when re-toggled filter, it will be more simpler.

Demo:

https://github.com/user-attachments/assets/684b2c4c-a64a-4968-895d-bb1861fa28bc

