### PR TITLE
feat: add AniLibria search provider

### DIFF
--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AniLibria.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AniLibria.kt
@@ -1,0 +1,128 @@
+package com.prajwalch.torrentsearch.providers
+
+import com.prajwalch.torrentsearch.domain.model.Category
+import com.prajwalch.torrentsearch.domain.model.Torrent
+import com.prajwalch.torrentsearch.extension.asArray
+import com.prajwalch.torrentsearch.extension.asObject
+import com.prajwalch.torrentsearch.extension.getLong
+import com.prajwalch.torrentsearch.extension.getObject
+import com.prajwalch.torrentsearch.extension.getString
+import com.prajwalch.torrentsearch.extension.getUInt
+import com.prajwalch.torrentsearch.util.FileSizeUtils
+import com.prajwalch.torrentsearch.util.TorrentDateParser
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Provider implementation backed by the public [AniLibria API](https://anilibria.top/api/v1).
+ *
+ * The search endpoint returns matching releases. The torrents for each release
+ * are fetched from a separate endpoint, then mapped to magnet-based [Torrent]s.
+ */
+class AniLibria : SearchProvider {
+    override val id = "anilibria"
+    override val name = "AniLibria"
+    override val url = "https://www.anilibria.top"
+    override val supportedCategories = setOf(Category.Anime)
+    override val safetyStatus = SearchProviderSafetyStatus.Safe
+    override val enabledByDefault = false
+
+    override suspend fun search(query: String, context: SearchContext): List<Torrent> {
+        val searchUrl = buildString {
+            append(API_URL)
+            append("/app/search/releases")
+            append("?query=$query")
+        }
+        val responseJson = context.httpClient.getJson(url = searchUrl) ?: return emptyList()
+
+        val releaseIds = withContext(Dispatchers.Default) {
+            responseJson
+                .asArray()
+                .map { it.asObject() }
+                .mapNotNull { it.getLong("id") }
+                .take(MAX_RELEASES)
+        }
+
+        return coroutineScope {
+            releaseIds
+                .map { releaseId -> async { fetchReleaseTorrents(context, releaseId) } }
+                .awaitAll()
+                .flatten()
+        }
+    }
+
+    /** Fetches and parses the torrents that belong to a single release. */
+    private suspend fun fetchReleaseTorrents(
+        context: SearchContext,
+        releaseId: Long,
+    ): List<Torrent> {
+        val torrentsUrl = "$API_URL/anime/torrents/release/$releaseId"
+        val responseJson = context.httpClient.getJson(url = torrentsUrl) ?: return emptyList()
+
+        return withContext(Dispatchers.Default) {
+            responseJson
+                .asArray()
+                .map { it.asObject() }
+                .mapNotNull { parseTorrentObject(it) }
+        }
+    }
+
+    /**
+     * Parses a single torrent entry into a [Torrent], or returns `null` if a
+     * required field is missing.
+     *
+     * Example structure (only the used fields are shown):
+     *
+     *     hash:       <string>
+     *     label:      <string>
+     *     size:       <number>
+     *     magnet:     <string>
+     *     seeders:    <number>
+     *     leechers:   <number>
+     *     created_at: <ISO 8601 string>
+     *     release:    { name: { english, main }, alias: <string> }
+     */
+    private fun parseTorrentObject(obj: JsonObject): Torrent? {
+        val infoHash = obj.getString("hash") ?: return null
+
+        val release = obj.getObject("release")
+        val releaseName = release
+            ?.getObject("name")
+            ?.let { it.getString("english") ?: it.getString("main") }
+        val name = obj.getString("label") ?: releaseName ?: return null
+
+        val size = obj.getLong("size")?.toFloat()?.let(FileSizeUtils::formatBytes)
+        val magnetUri = obj.getString("magnet")
+        val seeders = obj.getUInt("seeders")
+        val peers = obj.getUInt("leechers")
+        val uploadDate = obj.getString("created_at")?.let(TorrentDateParser::parseIso)
+        val descriptionPageUrl = release
+            ?.getString("alias")
+            ?.let { "$url/anime/releases/release/$it" }
+
+        return Torrent(
+            infoHash = infoHash,
+            name = name,
+            size = size,
+            seeders = seeders,
+            peers = peers,
+            providerName = this.name,
+            uploadDate = uploadDate,
+            category = Category.Anime,
+            descriptionPageUrl = descriptionPageUrl,
+            magnetUri = magnetUri,
+        )
+    }
+
+    private companion object {
+        private const val API_URL = "https://anilibria.top/api/v1"
+
+        /** Maximum number of matched releases to fetch torrents for. */
+        private const val MAX_RELEASES = 15
+    }
+}

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BuiltinSearchProviders.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BuiltinSearchProviders.kt
@@ -1,6 +1,7 @@
 package com.prajwalch.torrentsearch.providers
 
 val BuiltinSearchProviders = listOf(
+    AniLibria(),
     AniRena(),
     AnimeTosho(),
     AudioBookBay(),


### PR DESCRIPTION
## Summary

Adds AniLibria as a built-in anime search provider so users can find AniLibria releases directly in the app.

## Why this matters

Issue #97 tracks search providers still wanted, and AniLibria is listed as not yet added. AniLibria exposes a stable public JSON API, so the new `AniLibria` provider in `app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AniLibria.kt` follows the same JSON-API approach as `TorrentsCSV` and `Knaben` rather than HTML scraping. It searches releases via `/api/v1/app/search/releases`, fetches each release's torrents from `/api/v1/anime/torrents/release/{id}`, and maps them to `Torrent` objects (name, size, seeders, leechers, magnet, upload date, details page). One line registers it in the alphabetically ordered `BuiltinSearchProviders` list, from which the Hilt module and `DefaultEnabledProviderIds` derive automatically.

The provider sets `supportedCategories = setOf(Category.Anime)`, `safetyStatus = Safe`, and `enabledByDefault = false`, matching recently added providers. Malformed or non-2xx responses return an empty list via the shared `getJson` path instead of throwing.

## Testing

I exercised the AniLibria endpoints used here against live data ("One Piece"/"One Punch Man") to confirm the response shapes the parser reads. The Android/Kotlin build was not run locally because no JDK is installed in this environment; CI will compile it.

Fixes #97
