### PR TITLE
Migrate HTML parsing from Jsoup to fleeksoft/ksoup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .idea
 .DS_Store
 /build
+**/build/
 /captures
 .externalNativeBuild
 .cxx

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ no local setup needed, contribute directly from your browser.
 - **Storage:** [Room](https://developer.android.com/training/data-storage/room), [Jetpack DataStore](https://developer.android.com/topic/libraries/architecture/datastore)
 - **Dependency injection:** [Hilt](https://developer.android.com/training/dependency-injection/hilt-android)
 - **Image loading:** [Coil](https://coil-kt.github.io/coil/)
-- **HTML parsing**: [Jsoup](https://github.com/jhy/jsoup)
+- **HTML parsing**: [Ksoup](https://github.com/fleeksoft/ksoup)
 - **Immutable collections**: [Kotlinx immutable collections](https://github.com/Kotlin/kotlinx.collections.immutable)
 - **Markdown rendering**: [ComposeMarkdown](https://github.com/jeziellago/compose-markdown)
 - **Scrollbar**: [LazyColumnScrollbar](https://github.com/nanihadesuka/LazyColumnScrollbar)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,7 @@ dependencies {
     implementation(libs.coil.compose)
     implementation(libs.coil.network.ktor)
     implementation(libs.compose.markdown)
-    implementation(libs.jsoup)
+    implementation(libs.ksoup)
     implementation(libs.koin.android)
     implementation(libs.koin.androidx.compose)
     implementation(libs.koin.annotations)

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AniRena.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AniRena.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class AniRena(private val networkClient: NetworkClient) : SearchProvider,
     LatestTorrentsProvider,
@@ -83,7 +83,7 @@ private class AniRenaResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull { parseListItem(it) }
         }
@@ -156,7 +156,7 @@ private class AniRenaDetailsPageParser(private val networkClient: NetworkClient)
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val infoHash = html.selectFirst(INFO_HASH)
                 ?.ownText()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AnimeTosho.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AnimeTosho.kt
@@ -10,9 +10,9 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
-import org.jsoup.nodes.TextNode
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.TextNode
 
 import java.time.Instant
 
@@ -42,7 +42,7 @@ class AnimeTosho(private val networkClient: NetworkClient) : SearchProvider,
 
 private class AnimeToshoResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String): List<Torrent> = withContext(Dispatchers.Default) {
-        Jsoup
+        Ksoup
             .parse(html)
             .select("div.home_list_entry")
             .mapNotNull { parseEntryDiv(it) }
@@ -134,7 +134,7 @@ private object AnimeToshoDetailsPageParser {
 
     suspend fun parse(html: String, baseUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, baseUrl)
+            val html = Ksoup.parse(html, baseUrl)
 
             val name = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUriElem = html.selectFirst(MAGNET_URI) ?: return@withContext null
@@ -143,7 +143,7 @@ private object AnimeToshoDetailsPageParser {
             val infoHash = TorrentUtils.getInfoHashFromMagnetUri(magnetUri)
 
             val unprocessedSize = html.selectFirst(SIZE)?.ownText()
-                ?: magnetUriElem.nextSibling()?.takeIf { it is TextNode }?.nodeValue()
+                ?: (magnetUriElem.nextSibling() as? TextNode)?.text()
             val size = unprocessedSize
                 ?.trim()
                 ?.filterNot { it in setOf('(', ')', '|') }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AudioBookBay.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/AudioBookBay.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class AudioBookBay(private val networkClient: NetworkClient) : SearchProvider,
     LatestTorrentsProvider, TorrentDetailsProvider {
@@ -50,7 +50,7 @@ private class AudioBookBayResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -88,7 +88,7 @@ private class AudioBookBayResultsPageParser(
 
     private suspend fun getInfoHash(detailsPageUrl: String): String? {
         return networkClient.getText(detailsPageUrl)
-            .let(Jsoup::parse)
+            .let(Ksoup::parse)
             .selectFirst("td:containsOwn(Info Hash:)")
             ?.nextElementSibling()
             ?.ownText()
@@ -113,7 +113,7 @@ private object AudioBookBayDetailsPageParser {
     private const val POSTER_URL = """img[itemprop="image"]"""
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
         val infoHash = html.selectFirst(INFO_HASH)

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BTDigg.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BTDigg.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class BTDigg(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider {
     override val id = "btdigg"
@@ -39,7 +39,7 @@ class BTDigg(private val networkClient: NetworkClient) : SearchProvider, Torrent
 private class BTDiggResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
         }
@@ -81,7 +81,7 @@ private object BTDiggDetailsPageParser {
     private const val MAGNET_URI = """a[href^="magnet:?xt="]"""
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
         val torrentName = html.selectFirst(TORRENT_NAME)
             ?.nextElementSibling()
             ?.ownText()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BitSearch.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BitSearch.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 import java.time.format.DateTimeParseException
 
@@ -117,7 +117,7 @@ class BitSearch(private val networkClient: NetworkClient) :
 private class BitSearchResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull { parseListItem(it) }
@@ -194,7 +194,7 @@ private object BitSearchDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val name = html.selectFirst(NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BlueRoms.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/BlueRoms.kt
@@ -12,9 +12,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
-import org.jsoup.nodes.TextNode
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.TextNode
 
 import kotlin.io.encoding.Base64
 
@@ -48,7 +48,7 @@ private class BlueRomsResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -68,8 +68,8 @@ private class BlueRomsResultsPageParser(
 
         val size = listItem.selectFirst(SIZE)
             ?.nextSibling()
-            ?.takeIf { it is TextNode }
-            ?.nodeValue()
+            .let { it as? TextNode }
+            ?.text()
             ?.trim()
             ?.let(FileSizeUtils::normalizeSize)
         val detailsPageUrl = listItem.selectFirst(DETAILS_PAGE_URL)?.attr("abs:href")
@@ -108,7 +108,7 @@ private class BlueRomsDetailsPageParser(private val networkClient: NetworkClient
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
             val downloadPageUrl = html.selectFirst(DOWNLOAD_PAGE_LINK)
                 ?.attr("abs:href")
                 ?: return@withContext null
@@ -140,7 +140,7 @@ private class BlueRomsDetailsPageParser(private val networkClient: NetworkClient
 private suspend fun getMagnetUri(downloadPageUrl: String, networkClient: NetworkClient): String? {
     val downloadPageHtml = withContext(Dispatchers.IO) { networkClient.getText(downloadPageUrl) }
     val encodedMagnetUri = withContext(Dispatchers.Default) {
-        Jsoup.parse(downloadPageHtml)
+        Ksoup.parse(downloadPageHtml)
             .selectFirst("button#magnet-button")
             ?.attr("data-link")
             ?.takeIf { it.isNotBlank() }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Bt4g.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Bt4g.kt
@@ -13,9 +13,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
+import com.fleeksoft.ksoup.nodes.Element
 
 class Bt4g(private val networkClient: NetworkClient) : SearchProvider, LatestTorrentsProvider,
     TopTorrentsProvider, TorrentDetailsProvider {
@@ -79,7 +79,7 @@ private class Bt4gResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -145,7 +145,7 @@ private class Bt4gDetailsPageParser(private val networkClient: NetworkClient) {
     }
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val infoHash = extractInfoHash(html) ?: return@withContext null
         val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
@@ -189,7 +189,7 @@ private class Bt4gDetailsPageParser(private val networkClient: NetworkClient) {
         }
 
         return withContext(Dispatchers.Default) {
-            extractInfoHash(Jsoup.parse(detailsPageHtml))
+            extractInfoHash(Ksoup.parse(detailsPageHtml))
         }
     }
 

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Dmhy.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Dmhy.kt
@@ -11,8 +11,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Dmhy(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider,
     LatestTorrentsProvider, TopTorrentsProvider {
@@ -79,7 +79,7 @@ class Dmhy(private val networkClient: NetworkClient) : SearchProvider, TorrentDe
 private class DmhyResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
@@ -134,7 +134,7 @@ private object DmhyDetailsPageParser {
     private const val MAGNET_URI = "div#resource-tabs > div#tabs-1 > p:nth-child(2) > a#a_magnet"
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val torrentName = html.selectFirst(TORRENT_NAME)?.text() ?: return@withContext null
         val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Ext.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Ext.kt
@@ -16,9 +16,9 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Document
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Document
+import com.fleeksoft.ksoup.nodes.Element
 
 import java.security.MessageDigest
 
@@ -122,7 +122,7 @@ private class ExtResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
             val sessionId = html.selectFirst(SESSION_ID)?.attr("content")
             val pageToken = extractSearchPageToken(html)
 
@@ -249,7 +249,7 @@ private class ExtDetailsPageParser(private val networkClient: NetworkClient) {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentId = html.selectFirst(TORRENT_ID)?.attr("data-id") ?: return@withContext null
             val sessionId = html.selectFirst(SESSION_ID)?.attr("content") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Eztv.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Eztv.kt
@@ -10,9 +10,9 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
-import org.jsoup.nodes.TextNode
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
+import com.fleeksoft.ksoup.nodes.TextNode
 
 class Eztv(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider {
     override val id = "eztvx"
@@ -46,7 +46,7 @@ class Eztv(private val networkClient: NetworkClient) : SearchProvider, TorrentDe
 private class EztvResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .drop(2)
                 .mapNotNull(::parseListItem)
@@ -102,7 +102,7 @@ private object EztvDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
@@ -113,14 +113,14 @@ private object EztvDetailsPageParser {
             val size = torrentInfoContainer
                 ?.find { it.ownText() == "Filesize:" }
                 ?.nextSibling()
-                ?.takeIf { it is TextNode }
-                ?.nodeValue()
+                .let { it as? TextNode }
+                ?.text()
                 ?.trim()
             val uploadDate = torrentInfoContainer
                 ?.find { it.ownText() == "Released:" }
                 ?.nextSibling()
-                ?.takeIf { it is TextNode }
-                ?.nodeValue()
+                .let { it as? TextNode }
+                ?.text()
                 ?.trim()
                 ?.replace(Regex("(\\d+)(st|nd|rd|th)"), "$1")
                 ?.let { TorrentDateParser.parse(date = it, format = "d MMM yyyy") }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/FileMood.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/FileMood.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class FileMood(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider {
     override val id = "filemood"
@@ -43,7 +43,7 @@ class FileMood(private val networkClient: NetworkClient) : SearchProvider, Torre
 private class FileMoodResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
@@ -96,7 +96,7 @@ private object FileMoodDetailsPageParser {
         "div.well > table:nth-child(3) > tbody > tr:nth-child(5) > td:nth-child(2) > p"
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
         val infoHash = html.selectFirst(INFO_HASH)

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/LimeTorrents.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/LimeTorrents.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentDateParser
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 /**
  * Provider implementation for [LimeTorrents](https://www.limetorrents.lol).
@@ -115,7 +115,7 @@ private class LimeTorrentsResultsPageParser(private val providerName: String) {
         searchCategory: Category? = null,
     ): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull { parseListItem(it, searchCategory) }
         }
@@ -189,7 +189,7 @@ private object LimeTorrentsDetailsPageParser {
         "#content > div:nth-child(6) > div:nth-child(1) > div > div:nth-child(7) > div > a"
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val infoHash = html.selectFirst(INFO_HASH)?.ownText()?.lowercase()
             ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/LinuxTracker.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/LinuxTracker.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class LinuxTracker(private val networkClient: NetworkClient) : SearchProvider,
     LatestTorrentsProvider, TopTorrentsProvider,
@@ -52,7 +52,7 @@ class LinuxTracker(private val networkClient: NetworkClient) : SearchProvider,
 private class LinuxTrackerResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
         }
@@ -110,7 +110,7 @@ private object LinuxTrackerDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
             val size = html.selectFirst(SIZE)?.nextElementSibling()?.ownText()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/MegaPeer.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/MegaPeer.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class MegaPeer(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider {
     override val id = "megapeer"
@@ -76,7 +76,7 @@ private class MegaPeerResultsPageParser(
 
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -131,7 +131,7 @@ private class MegaPeersDetailsPageParser(private val networkClient: NetworkClien
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.text() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
@@ -219,7 +219,7 @@ private class MegaPeersDetailsPageParser(private val networkClient: NetworkClien
     suspend fun getMagnetUri(detailsPageUrl: String): String? {
         val detailsPageHtml = withContext(Dispatchers.IO) { networkClient.getText(detailsPageUrl) }
         return withContext(Dispatchers.Default) {
-            Jsoup.parse(detailsPageHtml).selectFirst(MAGNET_URI)?.attr("href")
+            Ksoup.parse(detailsPageHtml).selectFirst(MAGNET_URI)?.attr("href")
         }
     }
 }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Mikan.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Mikan.kt
@@ -11,8 +11,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Mikan(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider {
     override val id = "mikanproject"
@@ -40,7 +40,7 @@ class Mikan(private val networkClient: NetworkClient) : SearchProvider, TorrentD
 private class MikanResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
         }
@@ -90,7 +90,7 @@ private object MikanDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
             val fileDownloadLink = html.selectFirst(FILE_DOWNLOAD_LINK)?.attr("abs:href")

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/MyPornClub.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/MyPornClub.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class MyPornClub(private val networkClient: NetworkClient) :
     SearchProvider,
@@ -64,7 +64,7 @@ private class MyPornClubResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
@@ -131,7 +131,7 @@ private object MyPornClubDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val infoHash = html.selectFirst(INFO_HASH)
                 ?.ownText()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/NekoBT.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/NekoBT.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 // TODO: Use JSON API
 //       https://nekobt.to/search?query=one
@@ -58,7 +58,7 @@ class NekoBT(private val networkClient: NetworkClient) : SearchProvider, LatestT
 private class NekoBTResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
         }
@@ -125,7 +125,7 @@ private object NekoBTDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Nyaa.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Nyaa.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Nyaa(private val networkClient: NetworkClient) : SearchProvider, TorrentDetailsProvider,
     LatestTorrentsProvider, TopTorrentsProvider {
@@ -84,7 +84,7 @@ private class NyaaResultsPageParser(private val providerName: String) {
      */
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
         }
@@ -156,7 +156,7 @@ private object NyaaDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val name = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/OxTorrent.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/OxTorrent.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class OxTorrent(private val networkClient: NetworkClient) : SearchProvider, LatestTorrentsProvider,
     TopTorrentsProvider,
@@ -81,7 +81,7 @@ private class OxTorrentResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -129,7 +129,7 @@ private object OxTorrentDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URL)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Rutor.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Rutor.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Rutor(private val networkClient: NetworkClient) : SearchProvider, LatestTorrentsProvider,
     TopTorrentsProvider, TorrentDetailsProvider {
@@ -96,7 +96,7 @@ private class RutorResultsPageParser(private val providerName: String) {
         pageUrl: String,
         searchCategory: Category,
     ): List<Torrent> = withContext(Dispatchers.Default) {
-        Jsoup.parse(html, pageUrl)
+        Ksoup.parse(html, pageUrl)
             .select(LIST_ITEM)
             .drop(1)
             .mapNotNull { parseListItem(it, searchCategory) }
@@ -152,7 +152,7 @@ private object RutorDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.text() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
@@ -221,7 +221,7 @@ private object RutorDetailsPageParser {
             .find { it.selectFirst("div.hidehead")?.ownText() == "Скриншоты" }
             ?.selectFirst("textarea.hidearea")
             ?.ownText()
-            ?.let(Jsoup::parse)
+            ?.let(Ksoup::parse)
             ?.select("a > img")
             ?.mapNotNull { it.attr("src") }
     }

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/SubsPlease.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/SubsPlease.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
-import org.jsoup.Jsoup
+import com.fleeksoft.ksoup.Ksoup
 import java.time.Instant
 
 class SubsPlease(private val networkClient: NetworkClient) : SearchProvider, LatestTorrentsProvider,
@@ -125,7 +125,7 @@ private class SubsPleaseResultsJsonParser(
 private class SubsPleaseDetailsPageParser(private val networkClient: NetworkClient) {
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val showId = html.selectFirst("table#show-release-table")
                 ?.attr("sid")

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Sukebei.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Sukebei.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Sukebei(private val networkClient: NetworkClient) :
     SearchProvider,
@@ -62,7 +62,7 @@ class Sukebei(private val networkClient: NetworkClient) :
 private class SukebeiResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .mapNotNull(::parseListItem)
@@ -124,7 +124,7 @@ private object SukebeiDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val name = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TheRarBg.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TheRarBg.kt
@@ -14,8 +14,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class TheRarBg(private val networkClient: NetworkClient) :
     SearchProvider,
@@ -117,7 +117,7 @@ private class TheRarBgResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -174,7 +174,7 @@ private object TheRarBgDetailsPageParser {
     private const val MAGNET_URI = """a[href^="magnet:?"]"""
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val name = html.selectFirst(NAME)?.ownText() ?: return@withContext null
         val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/ThirteenThirtySevenX.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/ThirteenThirtySevenX.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 import java.time.Instant
 
@@ -82,7 +82,7 @@ private class ThirteenThirtySevenXResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default.limitedParallelism(3)) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -185,7 +185,7 @@ private object ThirteenThirtySevenXDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TokyoToshokan.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TokyoToshokan.kt
@@ -12,8 +12,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class TokyoToshokan(private val networkClient: NetworkClient) : SearchProvider,
     TorrentDetailsProvider, LatestTorrentsProvider,
@@ -84,7 +84,7 @@ class TokyoToshokan(private val networkClient: NetworkClient) : SearchProvider,
 private class TokyoToshokanResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .zipWithNext()
@@ -155,7 +155,7 @@ private object TokyoToshokanDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val nameAnchor = html.selectFirst(NAME) ?: return@withContext null
             val name = nameAnchor.text()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Torrent9.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Torrent9.kt
@@ -13,8 +13,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Torrent9(private val networkClient: NetworkClient) : SearchProvider, LatestTorrentsProvider,
     TopTorrentsProvider,
@@ -82,7 +82,7 @@ private class Torrent9ResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -130,7 +130,7 @@ private object Torrent9DetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URL)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentDatabase.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentDatabase.kt
@@ -11,8 +11,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class TorrentDatabase(private val networkClient: NetworkClient) : SearchProvider,
     TorrentDetailsProvider,
@@ -99,7 +99,7 @@ class TorrentDatabase(private val networkClient: NetworkClient) : SearchProvider
 private class TdResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup
+            Ksoup
                 .parse(html, pageUrl)
                 .select(RESULT_LIST_ITEM)
                 .mapNotNull { parseListItem(it) }
@@ -175,7 +175,7 @@ private object TdDetailsPageParser {
 
     suspend fun parse(html: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html)
+            val html = Ksoup.parse(html)
 
             val name = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentDownload.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentDownload.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class TorrentDownload(private val networkClient: NetworkClient) :
     SearchProvider,
@@ -71,7 +71,7 @@ class TorrentDownload(private val networkClient: NetworkClient) :
 private class TorrentDownloadResultsParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             if (html.selectFirst("h2")?.ownText() == "No Results Found") {
                 emptyList()
@@ -138,7 +138,7 @@ private object TorrentDownloadDetailsPageParser {
     private const val FILE_DOWNLOAD_LINK = """a[href^="https://itorrent.net/"]"""
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
 
         val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
         val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentDownloads.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentDownloads.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class TorrentDownloads(private val networkClient: NetworkClient) : SearchProvider,
     LatestTorrentsProvider, TopTorrentsProvider,
@@ -124,7 +124,7 @@ private class TorrentDownloadsResultsPageParser(
 
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default.limitedParallelism(3)) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM_CONTAINER)
                 .last()
                 ?.select(LIST_ITEM)
@@ -186,7 +186,7 @@ private object TorrentDownloadsDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentKitty.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/TorrentKitty.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class TorrentKitty(private val networkClient: NetworkClient) : SearchProvider,
     TorrentDetailsProvider {
@@ -40,7 +40,7 @@ class TorrentKitty(private val networkClient: NetworkClient) : SearchProvider,
 private class TorrentKittyResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .drop(1)
                 .mapNotNull(::parseListItem)
@@ -88,7 +88,7 @@ private object TorrentKittyDetailsPageParser {
     private const val UPLOAD_DATE_FORMAT = "yyyy-MM-dd"
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
         val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
         val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
         val size = html.selectFirst(SIZE)?.ownText()?.uppercase()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Torrentz.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/Torrentz.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class Torrentz(private val networkClient: NetworkClient) : SearchProvider, LatestTorrentsProvider,
     TopTorrentsProvider,
@@ -114,7 +114,7 @@ private class TorrentzResultsPageParser(
 
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -157,7 +157,7 @@ private object TorrentzDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null
             val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
             val size = html.selectFirst(SIZE_LABEL)?.nextElementSibling()?.ownText()

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/UIndex.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/UIndex.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 import java.time.Instant
 
@@ -98,7 +98,7 @@ class UIndex(private val networkClient: NetworkClient) : SearchProvider, Torrent
 private class UIndexResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .selectFirst(LIST_ITEM_CONTAINER)
                 ?.select(LIST_ITEM)
                 ?.mapNotNull(::parseListItem)
@@ -162,7 +162,7 @@ private object UIndexDetailsPageParser {
 
     suspend fun parse(responseHtml: String, baseUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(responseHtml, baseUrl)
+            val html = Ksoup.parse(responseHtml, baseUrl)
 
             // Required data. Return early as possible.
             val name = html.selectFirst(NAME)?.ownText() ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/XXXClub.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/XXXClub.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class XXXClub(private val networkClient: NetworkClient) :
     SearchProvider,
@@ -62,7 +62,7 @@ private class XXXClubResultsPageParser(
 ) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .selectFirst(LIST_ITEM_CONTAINER)
                 ?.select(LIST_ITEM)
                 ?.map { async { parseListItem(it) } }
@@ -135,7 +135,7 @@ private object XXXClubDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val name = html.selectFirst(NAME)?.ownText() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/XXXTracker.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/XXXTracker.kt
@@ -10,8 +10,8 @@ import com.prajwalch.torrentsearch.util.TorrentUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class XXXTracker(private val networkClient: NetworkClient) :
     SearchProvider,
@@ -88,7 +88,7 @@ class XXXTracker(private val networkClient: NetworkClient) :
 private class XXXTrackerResultsPageParser(private val providerName: String) {
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 // First item is used as a header.
                 .drop(1)
@@ -149,7 +149,7 @@ private object XXXTrackerDetailsPageParser {
 
     suspend fun parse(html: String, pageUrl: String): TorrentDetails? =
         withContext(Dispatchers.Default) {
-            val html = Jsoup.parse(html, pageUrl)
+            val html = Ksoup.parse(html, pageUrl)
 
             val name = html.selectFirst(NAME)?.text() ?: return@withContext null
             val magnetUri = html.selectFirst(MAGNET_URI)?.attr("href") ?: return@withContext null

--- a/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/ZeroMagnet.kt
+++ b/app/src/main/kotlin/com/prajwalch/torrentsearch/providers/ZeroMagnet.kt
@@ -12,8 +12,8 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.jsoup.Jsoup
-import org.jsoup.nodes.Element
+import com.fleeksoft.ksoup.Ksoup
+import com.fleeksoft.ksoup.nodes.Element
 
 class ZeroMagnet(private val networkClient: NetworkClient) : SearchProvider,
     TorrentDetailsProvider {
@@ -51,7 +51,7 @@ private class ZeroMagnetResultsPageParser(
 
     suspend fun parse(html: String, pageUrl: String): List<Torrent> =
         withContext(Dispatchers.Default) {
-            Jsoup.parse(html, pageUrl)
+            Ksoup.parse(html, pageUrl)
                 .select(LIST_ITEM)
                 .map { async { parseListItem(it) } }
                 .awaitAll()
@@ -83,7 +83,7 @@ private object ZeroMagnetDetailsPageParser {
     private const val MAGNET_URI = "input#input-magnet"
 
     suspend fun parse(html: String): TorrentDetails? = withContext(Dispatchers.Default) {
-        val html = Jsoup.parse(html)
+        val html = Ksoup.parse(html)
         val torrentName = html.selectFirst(TORRENT_NAME)?.ownText() ?: return@withContext null
         val magnetUri = html.selectFirst(MAGNET_URI)?.attr("value") ?: return@withContext null
         val size = html.selectFirst(SIZE)?.ownText()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ coreSplashscreen = "1.2.0"
 datastorePreferences = "1.2.1"
 desugarJdkLibs = "2.1.5"
 espressoCore = "3.7.0"
-jsoup = "1.23.1"
+ksoup = "0.2.6"
 junit = "4.13.2"
 junitVersion = "1.3.0"
 koin = "4.2.2"
@@ -50,7 +50,7 @@ coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref 
 coil-network-ktor = { group = "io.coil-kt.coil3", name = "coil-network-ktor3", version.ref = "coil" }
 compose-markdown = { group = "com.github.jeziellago", name = "compose-markdown", version.ref = "composeMarkdown" }
 desugar-jdk-libs = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdkLibs" }
-jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
+ksoup = { group = "com.fleeksoft.ksoup", name = "ksoup", version.ref = "ksoup" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 koin-android = { group = "io.insert-koin", name = "koin-android", version.ref = "koin" }
 koin-androidx-compose = { group = "io.insert-koin", name = "koin-androidx-compose", version.ref = "koin" }


### PR DESCRIPTION
As mentioned: https://github.com/prajwalch/TorrentSearch/pull/108#issuecomment-5276113544 there are some steps to be taken in order to migrate to multiplatform support. Starting with Jsoup which can be replaced with a drop in Ksoup replacement. 

## Summary
- Replace JVM-only Jsoup with [fleeksoft/ksoup](https://github.com/fleeksoft/ksoup) (`0.2.6`), a KMP-compatible Jsoup port, so HTML parsing is ready for a future multiplatform split.
- Migrate all HTML search-provider parsers to `Ksoup` (imports/parse calls), with a small `nodeValue()` → `TextNode.text()` API adjustment where needed.
- Ignore nested `**/build/` directories so module build outputs are not untracked.

## Test plan
- [ ] `./gradlew :app:compileDebugKotlin` succeeds
- [ ] Spot-check a few providers that use `attr("abs:href")` (base URI still passed to `Ksoup.parse`)
- [ ] Spot-check Eztv / BlueRoms / AnimeTosho details parsing (former `nodeValue()` paths)
- [x] Confirm `androidApp/build` (and other nested `build/`) stay ignored by git

